### PR TITLE
Add weak reference to window on AppCoordinator

### DIFF
--- a/Currencies/Currencies/Coordinator/AppCoordinator.swift
+++ b/Currencies/Currencies/Coordinator/AppCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class AppCoordinator: Coordinator {
     
-    private let window: UIWindow
+    private weak var window: UIWindow?
     private let container: DefaultContainer
     
     init(window: UIWindow,
@@ -24,7 +24,7 @@ final class AppCoordinator: Coordinator {
         
         let exchangeView = container.container.resolve(ExchangeRatesView.self)!
         
-        self.window.rootViewController = exchangeView
+        self.window?.rootViewController = exchangeView
         
     }
 }


### PR DESCRIPTION
## Description
This PR adds the weak keyword to the window reference on AppCoordinator

### WHY
To remove the strong reference, therefore avoiding retain cycle.