### PR TITLE
Add verification on textfield text

### DIFF
--- a/Currencies/Currencies/Modules/ExchangeRatesView/ExchangeRatesView.swift
+++ b/Currencies/Currencies/Modules/ExchangeRatesView/ExchangeRatesView.swift
@@ -133,7 +133,6 @@ extension ExchangeRatesView: UITableViewDataSource {
             cell.view.amountTextField.text = String(format: "%.2f", self.currentAmount)
             cell.view.amountTextField.isUserInteractionEnabled = true
             cell.view.amountTextField.delegate = self
-            cell.view.amountTextField.addTarget(self, action: #selector(editingChange(_:)), for: .editingChanged)
             return cell
         }
 
@@ -142,16 +141,6 @@ extension ExchangeRatesView: UITableViewDataSource {
         cell.view.amountTextField.isUserInteractionEnabled = false
         return cell
     }
-
-  @objc func editingChange(_ textField: UITextField) {
-    let numberString = textField.text ?? ""
-    self.currentAmount = numberString.toDouble()
-
-    self.ratesFormatted = self.viewModel
-        .getUpdatedRatesFormattedFor(currentAmount: self.currentAmount)
-
-    self.updateTableView()
-  }
 }
 
 extension ExchangeRatesView: UITextFieldDelegate {
@@ -161,4 +150,22 @@ extension ExchangeRatesView: UITextFieldDelegate {
       textField.text = ""
     }
   }
+
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+
+        let currentText = textField.text ?? ""
+        let replacementText = (currentText as NSString).replacingCharacters(in: range, with: string)
+
+        let shouldChange = self.viewModel.shouldChangeAmountTextField(amountString: replacementText)
+        if shouldChange {
+            self.currentAmount = replacementText.toDouble()
+
+            self.ratesFormatted = self.viewModel
+                .getUpdatedRatesFormattedFor(currentAmount: self.currentAmount)
+
+            self.updateTableView()
+            return true
+        }
+        return false
+    }
 }

--- a/Currencies/Currencies/Modules/ExchangeRatesView/ExchangeRatesViewModel.swift
+++ b/Currencies/Currencies/Modules/ExchangeRatesView/ExchangeRatesViewModel.swift
@@ -46,6 +46,13 @@ final class ExchangeRatesViewModel {
         }
     }
 
+    func shouldChangeAmountTextField(amountString: String) -> Bool {
+        let isNotLeftZero = amountString != "0"
+        let isValidDouble = amountString.isValidDouble(maxDecimalPlaces: 4)
+        let isEmpty = amountString.isEmpty
+        return ((isValidDouble || isEmpty) && isNotLeftZero)
+    }
+
     func getUpdatedRatesFormattedFor(currentAmount: Double) -> [RateFormatted] {
         return self.ratesFormatted.map { $0.updateWith(currentAmount: currentAmount) }
     }

--- a/Currencies/Currencies/Utils/String+Utils.swift
+++ b/Currencies/Currencies/Utils/String+Utils.swift
@@ -13,3 +13,18 @@ extension String {
         return Double(self) ?? 0.0
     }
 }
+
+extension String {
+    func isValidDouble(maxDecimalPlaces: Int) -> Bool {
+        let formatter = NumberFormatter()
+        formatter.allowsFloats = true
+        let decimalSeparator = formatter.decimalSeparator ?? "."
+
+        if formatter.number(from: self) != nil {
+            let splitString = self.components(separatedBy: decimalSeparator)
+            let digits = splitString.count == 2 ? splitString.last ?? "" : ""
+            return digits.count <= maxDecimalPlaces
+        }
+        return false
+    }
+}

--- a/Currencies/CurrenciesTests/Modules/ExchangeRatesView/ExchangeRatesViewModelSpec.swift
+++ b/Currencies/CurrenciesTests/Modules/ExchangeRatesView/ExchangeRatesViewModelSpec.swift
@@ -20,8 +20,6 @@ class ExchangeRatesViewModelSpec: QuickSpec {
         describe("Exchange Rates View Behaviour") {
             context("Received Rates From Service") {
                 beforeEach {
-
-
                     let result = Result<RateResult, NetworkError>.success(RateResult(base: "EUR", date: "10-02-2019", rates: ["EUR": 1.0, "BRL": 4.0, "USD": 1.5]))
 
                     self.ratesService = MockExchangeRateService(ratesResult: result)
@@ -58,6 +56,13 @@ class ExchangeRatesViewModelSpec: QuickSpec {
                     amounts = newRatesFormatted.map { $0.finalAmount }
                     expect(amounts) == ["400.00", "100.00", "150.00"]
 
+                }
+
+                it("Check Should Change TextField Function") {
+
+                    let amounts = ["10", "10.", "1","", "0", "."]
+                    let subjectsArray = amounts.map { self.subject.shouldChangeAmountTextField(amountString: $0)}
+                    expect(subjectsArray) == [true,true,true,true,false,false]
                 }
 
 

--- a/Currencies/CurrenciesTests/Utils/StringSpec.swift
+++ b/Currencies/CurrenciesTests/Utils/StringSpec.swift
@@ -38,5 +38,38 @@ class StringSpec: QuickSpec {
                 expect(subject) == 0
             }
         }
+
+        describe("Is Valid Double Function Behaviour") {
+
+            it("Check Value When It I A Valid Double") {
+                let string = "10.00"
+                let subject = string.isValidDouble(maxDecimalPlaces: 4)
+                expect(subject) == true
+            }
+
+            it("Check Value When It I A Valid Int") {
+                let string = "10"
+                let subject = string.isValidDouble(maxDecimalPlaces: 4)
+                expect(subject) == true
+            }
+
+            it("Check Value When It I Not A Valid Double") {
+                let string = "notanumber"
+                let subject = string.isValidDouble(maxDecimalPlaces: 4)
+                expect(subject) == false
+            }
+
+            it("Check Value When Empty String") {
+                let string = ""
+                let subject = string.isValidDouble(maxDecimalPlaces: 4)
+                expect(subject) == false
+            }
+
+            it("Check When Value Has More Decimal Places") {
+                let string = "10.00001"
+                let subject = string.isValidDouble(maxDecimalPlaces: 4)
+                expect(subject) == false
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR adds logic to filter elements that don't make sense as value, in special, more than one dot/comma to separate the decimals.

### WHY
Previously it was possible to add more than one dot/comma what is not user friendly.

closes #15 